### PR TITLE
Fix local date formatting and add timezone tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+import { formatDate } from './date-utils.js';
+
 const STORAGE_KEYS = {
   TEXT: 'todotxt-lines',
   ORDER: 'todotxt-order',
@@ -79,11 +81,6 @@ function parseISO(str) {
   const [year, month, day] = str.split('-').map(Number);
   if (!year || !month || !day) return null;
   return new Date(year, month - 1, day);
-}
-
-function formatDate(date) {
-  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  return d.toISOString().slice(0, 10);
 }
 
 function shiftDate(date, { days = 0, weeks = 0, months = 0, years = 0 }) {

--- a/date-utils.js
+++ b/date-utils.js
@@ -1,0 +1,11 @@
+export function formatDate(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    throw new TypeError('Expected a valid Date instance');
+  }
+  const utcMidnight = new Date(Date.UTC(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate()
+  ));
+  return utcMidnight.toISOString().slice(0, 10);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "todotxt",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/format-date.test.js
+++ b/tests/format-date.test.js
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatDate } from '../date-utils.js';
+
+function simulateTimezone(date, offsetMinutes) {
+  const adjust = offsetMinutes * 60_000;
+  const keys = ['getFullYear', 'getMonth', 'getDate'];
+  const originals = new Map();
+
+  for (const key of keys) {
+    const descriptor = Object.getOwnPropertyDescriptor(date, key);
+    originals.set(key, descriptor || null);
+    Object.defineProperty(date, key, {
+      configurable: true,
+      writable: true,
+      value: function () {
+        const adjusted = new Date(this.getTime() + adjust);
+        switch (key) {
+          case 'getFullYear':
+            return adjusted.getUTCFullYear();
+          case 'getMonth':
+            return adjusted.getUTCMonth();
+          case 'getDate':
+            return adjusted.getUTCDate();
+          default:
+            return Reflect.apply(Date.prototype[key], this, []);
+        }
+      }
+    });
+  }
+
+  return () => {
+    for (const key of keys) {
+      const descriptor = originals.get(key);
+      if (descriptor) {
+        Object.defineProperty(date, key, descriptor);
+      } else {
+        delete date[key];
+      }
+    }
+  };
+}
+
+test('formatDate keeps the current day in neutral timezone', () => {
+  const date = new Date(Date.UTC(2023, 4, 17, 12, 0, 0));
+  assert.equal(formatDate(date), '2023-05-17');
+});
+
+test('formatDate respects positive timezone offsets', () => {
+  const date = new Date(Date.UTC(2023, 4, 17, 22, 30, 0));
+  const restore = simulateTimezone(date, 120); // UTC+2
+  try {
+    assert.equal(formatDate(date), '2023-05-18');
+  } finally {
+    restore();
+  }
+});
+
+test('formatDate respects negative timezone offsets', () => {
+  const date = new Date(Date.UTC(2023, 4, 18, 5, 30, 0));
+  const restore = simulateTimezone(date, -420); // UTC-7
+  try {
+    assert.equal(formatDate(date), '2023-05-17');
+  } finally {
+    restore();
+  }
+});
+
+test('formatDate always returns a YYYY-MM-DD string', () => {
+  const date = new Date(Date.UTC(2023, 0, 5, 0, 0, 0));
+  assert.match(formatDate(date), /^\d{4}-\d{2}-\d{2}$/);
+});
+
+test('throws for invalid dates', () => {
+  assert.throws(() => formatDate(new Date('invalid')), {
+    name: 'TypeError'
+  });
+});


### PR DESCRIPTION
## Summary
- extract `formatDate` into a shared module that normalises dates at UTC midnight to avoid timezone-induced shifts
- continue providing `YYYY-MM-DD` strings for recurrence, filters, and completion logic via the shared helper
- add node-based tests with simulated timezone offsets and wire them up via `npm test`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd14c9808483278aea1e74e713ce8c