### PR TITLE
Normalize formatDate handling across timezones

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+import { formatDate } from './date-utils.js';
+
 const STORAGE_KEYS = {
   TEXT: 'todotxt-lines',
   ORDER: 'todotxt-order',
@@ -79,11 +81,6 @@ function parseISO(str) {
   const [year, month, day] = str.split('-').map(Number);
   if (!year || !month || !day) return null;
   return new Date(year, month - 1, day);
-}
-
-function formatDate(date) {
-  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  return d.toISOString().slice(0, 10);
 }
 
 function shiftDate(date, { days = 0, weeks = 0, months = 0, years = 0 }) {

--- a/date-utils.js
+++ b/date-utils.js
@@ -1,0 +1,19 @@
+const MS_PER_MINUTE = 60_000;
+const MS_PER_DAY = 86_400_000;
+
+export function formatDate(date, { timeZoneOffsetMinutes } = {}) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    throw new TypeError('Expected a valid Date instance');
+  }
+
+  const offset = timeZoneOffsetMinutes ?? date.getTimezoneOffset();
+  if (!Number.isFinite(offset)) {
+    throw new TypeError('Expected a finite timezone offset');
+  }
+
+  const localTimeMs = date.getTime() - offset * MS_PER_MINUTE;
+  const normalizedTime = Math.floor(localTimeMs / MS_PER_DAY) * MS_PER_DAY;
+  const normalizedDate = new Date(normalizedTime);
+
+  return normalizedDate.toISOString().slice(0, 10);
+}

--- a/date-utils.js
+++ b/date-utils.js
@@ -1,6 +1,14 @@
 const MS_PER_MINUTE = 60_000;
 const MS_PER_DAY = 86_400_000;
 
+/**
+ * Convert a Date into a local calendar day string (`YYYY-MM-DD`).
+ *
+ * @param {Date} date - The date to normalise.
+ * @param {{ timeZoneOffsetMinutes?: number }} [options] - Optional override for the
+ *   timezone offset in minutes. Positive values represent locations behind UTC.
+ * @returns {string} The ISO formatted date for the local day.
+ */
 export function formatDate(date, { timeZoneOffsetMinutes } = {}) {
   if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
     throw new TypeError('Expected a valid Date instance');

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>todo.txt Studio</title>
   <link rel="manifest" href="manifest.webmanifest">
   <link rel="stylesheet" href="styles.css" />
+  <link rel="modulepreload" href="date-utils.js" />
 </head>
 <body>
   <div id="app" class="app-shell" data-theme="auto">

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -2,6 +2,7 @@
   "name": "todo.txt Studio",
   "short_name": "todo.txt",
   "start_url": "./index.html",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#101017",
   "theme_color": "#3a7afe"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "todotxt",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,9 +1,10 @@
-const CACHE_NAME = 'todotxt-studio-v1';
+const CACHE_NAME = 'todotxt-studio-v2';
 const ASSETS = [
   './',
   './index.html',
   './styles.css',
   './app.js',
+  './date-utils.js',
   './todo.txt',
   './manifest.webmanifest'
 ];

--- a/tests/format-date.test.js
+++ b/tests/format-date.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatDate } from '../date-utils.js';
+
+test('formatDate keeps the current day in neutral timezone', () => {
+  const date = new Date(Date.UTC(2023, 4, 17, 12, 0, 0));
+  assert.equal(formatDate(date), '2023-05-17');
+});
+
+test('formatDate respects positive timezone offsets', () => {
+  const date = new Date(Date.UTC(2023, 4, 17, 22, 30, 0));
+  assert.equal(formatDate(date, { timeZoneOffsetMinutes: -120 }), '2023-05-18');
+});
+
+test('formatDate respects negative timezone offsets', () => {
+  const date = new Date(Date.UTC(2023, 4, 18, 5, 30, 0));
+  assert.equal(formatDate(date, { timeZoneOffsetMinutes: 420 }), '2023-05-17');
+});
+
+test('formatDate supports fractional timezone offsets', () => {
+  const date = new Date(Date.UTC(2023, 0, 1, 18, 30, 0));
+  assert.equal(formatDate(date, { timeZoneOffsetMinutes: -345 }), '2023-01-02');
+});
+
+test('formatDate defaults to the instance timezone offset', () => {
+  const date = new Date(Date.UTC(2023, 4, 17, 22, 30, 0));
+  date.getTimezoneOffset = () => -120;
+  assert.equal(formatDate(date), '2023-05-18');
+});
+
+test('formatDate does not mutate the provided date', () => {
+  const date = new Date(Date.UTC(2023, 4, 17, 12, 0, 0));
+  const originalTime = date.getTime();
+  formatDate(date, { timeZoneOffsetMinutes: -120 });
+  assert.equal(date.getTime(), originalTime);
+});
+
+test('formatDate always returns a YYYY-MM-DD string', () => {
+  const date = new Date(Date.UTC(2023, 0, 5, 0, 0, 0));
+  assert.match(formatDate(date), /^\d{4}-\d{2}-\d{2}$/);
+});
+
+test('formatDate normalises historical dates across offsets', () => {
+  const date = new Date(Date.UTC(1965, 0, 1, 3, 0, 0));
+  assert.equal(formatDate(date, { timeZoneOffsetMinutes: 600 }), '1964-12-31');
+});
+
+test('throws for invalid dates', () => {
+  assert.throws(() => formatDate(new Date('invalid')), {
+    name: 'TypeError'
+  });
+});
+
+test('throws when timezone offset is not finite', () => {
+  const date = new Date(Date.UTC(2023, 0, 1, 0, 0, 0));
+  assert.throws(() => formatDate(date, { timeZoneOffsetMinutes: Number.POSITIVE_INFINITY }), {
+    name: 'TypeError',
+    message: 'Expected a finite timezone offset'
+  });
+});
+
+test('throws when timezone offset is NaN', () => {
+  const date = new Date(Date.UTC(2023, 0, 1, 0, 0, 0));
+  assert.throws(() => formatDate(date, { timeZoneOffsetMinutes: Number.NaN }), {
+    name: 'TypeError',
+    message: 'Expected a finite timezone offset'
+  });
+});


### PR DESCRIPTION
## Summary
- floor the timezone-adjusted timestamp to whole-day increments before creating the ISO string
- extend the formatDate tests with a historical offset case to prevent regressions around pre-epoch dates
- preload the shared date helper, update the web manifest scope, and cache the helper for offline usage
- add a timezone-aware test harness plus coverage for invalid offsets, including NaN inputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd14c9808483278aea1e74e713ce8c